### PR TITLE
feat(spawn): add permission

### DIFF
--- a/packages/spawn/src/index.ts
+++ b/packages/spawn/src/index.ts
@@ -32,7 +32,7 @@ export const name = 'spawn'
 export function apply(ctx: Context, config: Config) {
   ctx.i18n.define('zh-CN', require('./locales/zh-CN'))
 
-  ctx.command('exec <command:text>')
+  ctx.command('exec <command:text>', { authority: 4 })
     .action(async ({ session }, command) => {
       if (!command) return session.text('.expect-text')
 


### PR DESCRIPTION
shutdown 插件默认的权限要求是 4，我认为 spawn 插件应该和 shutdown 插件一致