### PR TITLE
修复 recall 插件引用消息撤回时出现参数无效的 BUG

### DIFF
--- a/packages/recall/src/index.ts
+++ b/packages/recall/src/index.ts
@@ -23,8 +23,8 @@ export function apply(ctx: Context, { timeout }: Config) {
     ctx.setTimeout(() => remove(list, session.messageId), timeout)
   })
 
-  ctx.command('recall [count:number]', { authority: 2 })
-    .action(async ({ session }, count = 1) => {
+  ctx.command('recall [count]', { authority: 2 })
+    .action(async ({ session }, count: any = 1) => {
       const list = recent[session.channelId]
       if (session.quote) {
         const index = list?.findIndex(id => id === session.quote.id)


### PR DESCRIPTION
# 补充信息
Node: 20.10.0
Koishi: 4.17.10 
Console: 5.28.4
Adapter: onebot
OS: Windows 11 10.0.22621
> `撤回` 为 `recall` 的指令别名，用原指令 `recall` 也是同样的问题。
## 未修改时
![7c411c1f1c1029618304d66132b8011a](https://github.com/user-attachments/assets/a2567ddc-58a9-49f9-81bd-64a78a155ebc)
## 修改后
![8d32bd5d8bd0e02c11e7ce04a51f73d0](https://github.com/user-attachments/assets/e13e20d9-e8eb-4c21-8912-9217d21d8ea7)
## 引用消息撤回时的 Session 值如下
![image](https://github.com/user-attachments/assets/b8d497e6-f3fb-41a8-afc8-8c710cc04ed2)

```typescript

const Session = {
    id: 78,
        event: {
        selfId: '2152579699',
            platform: 'onebot',
            timestamp: 1722055604000,
            type: 'message-created',
            message: {
            messageId: '-2147418663',
                id: '-2147418663',
                elements: [Array],
                quote: [Object],
                content: '<at id="2152579699"/> 撤回'
        },
        subtype: 'group',
            subsubtype: 'group',
            _type: 'onebot',
            _data: {
            self_id: 2152579699,
                user_id: 1514586023,
                time: 1722055604,
                message_id: -2147418663,
                message_seq: -2147418663,
                real_id: -2147418663,
                message_type: 'group',
                sender: [Object],
                raw_message: '[CQ:reply,id=-2147418669][CQ:at,qq=2152579699] 撤回',
                font: 14,
                sub_type: 'normal',
                message: [Array],
                message_format: 'array',
                post_type: 'message',
                group_id: 466457124
        }
    },
    // ...
    locales: [],
        _stripped: {
        hasAt: false,
            content: '撤回',
            appel: true,
            atSelf: true,
            prefix: ''
    }
}
```